### PR TITLE
Move descriptor set registry from FrameGraph to Executor

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,1 +1,6 @@
 blank_issues_enabled: false
+
+contact_links:
+  - name: Project Discussions
+    url: https://github.com/RITIKESHDUTT/gLexShrD/discussions
+    about: Share ideas, ask questions, report bugs, or suggest improvements.

--- a/src/core/exec/executor.rs
+++ b/src/core/exec/executor.rs
@@ -1,3 +1,4 @@
+use crate::domain::DescriptorSetId;
 use crate::core::types::IndexType;
 use {
 	crate::{
@@ -36,6 +37,7 @@ pub struct Executor<'dev, B: Backend> {
 	compute: Option<WorkLane<'dev, Queue<Compute, B>, B>>,
 	transfer: Option<WorkLane<'dev, Queue<Transfer, B>, B>>,
 	present_sync: Option<PresentSync<B>>,
+	descriptor_sets: Vec<B::DescriptorSet>,
 }
 
 pub struct RenderTarget<'a, B: Backend> {
@@ -184,6 +186,7 @@ impl<'dev, B: Backend> Executor<'dev, B> {
 			compute: None,
 			transfer: None,
 			present_sync: None,
+			descriptor_sets: Vec::new(),
 		}
 	}
 	
@@ -261,11 +264,19 @@ impl<'dev, B: Backend> Executor<'dev, B> {
 	pub fn graphics_timeline_handle(&self) -> B::Semaphore {
 		self.graphics_lane().timeline_handle()
 	}
+	pub fn register_descriptor_set(&mut self, handle: B::DescriptorSet) -> DescriptorSetId {
+		let id = DescriptorSetId(self.descriptor_sets.len() as u32);
+		self.descriptor_sets.push(handle);
+		id
+	}
+	pub fn clear_descriptor_sets(&mut self) {
+		self.descriptor_sets.clear();
+	}
 	
 	// ── CHANGED: FrameGraph<B> (no 'f), match on domain, replay commands ──
 	pub fn execute(
 		&mut self,
-		graph: FrameGraph<B>,
+		graph: FrameGraph,
 		swap_img: SwapchainImage<'dev, img_state::Undefined, B>,
 		target: RenderTarget<'_, B>,
 		pipelines: &PipelineManager<'dev, B>,
@@ -275,7 +286,7 @@ impl<'dev, B: Backend> Executor<'dev, B> {
 		let ExecutionOrder { ordered_passes, barriers } = compiled.order;
 		let mut passes: HashMap<PassId, CompiledPass> = compiled.passes.into_iter().map(|p| (p.id, p)).collect();
 		let resources = compiled.resources;
-		let descriptor_sets = compiled.descriptor_sets; // NEW: carried from FrameGraph
+		let descriptor_sets = &self.descriptor_sets;
 		
 		let mut final_graphics_val: u64 = 0;
 		

--- a/src/core/exec/frame.rs
+++ b/src/core/exec/frame.rs
@@ -2,7 +2,6 @@ use crate::core::exec::command::PassCommand;
 use crate::core::render::cache::PipelineId;
 use {
 	crate::core::{
-		backend::Backend,
 		type_state_queue::{Compute, Graphics, Transfer},
 		types::PushConstantRange,
 	},
@@ -75,8 +74,8 @@ pub struct PassDecl {
 /// PassBuilder<Graphics> is a compile error.
 // Removed:  'f lifetime
 // Added:    domain, descriptor_set, commands fields
-pub struct PassBuilder<'a, D, B: Backend> {
-	graph: &'a mut FrameGraph<B>,
+pub struct PassBuilder<'a, D> {
+	graph: &'a mut FrameGraph,
 	id: PassId,
 	domain: PassDomain,
 	pipeline: Option<PipelineId>,
@@ -89,7 +88,7 @@ pub struct PassBuilder<'a, D, B: Backend> {
 
 // ─── Generic impl (all domains) ─────────────────────────────
 
-impl<D, B: Backend> PassBuilder<'_, D, B> {
+impl<D> PassBuilder<'_, D> {
 	pub fn reads(mut self, resource: ResourceId, usage: UsageIntent) -> Self {
 		self.reads.push((resource, usage));
 		self
@@ -155,7 +154,7 @@ impl<D, B: Backend> PassBuilder<'_, D, B> {
 // ─── Graphics impl ──────────────────────────────────────────
 // Compile-time enforced: only PassBuilder<Graphics> can call these.
 
-impl<B: Backend> PassBuilder<'_, Graphics, B> {
+impl PassBuilder<'_, Graphics> {
 	pub fn bind_pipeline(mut self, id: PipelineId) -> Self {
 		self.commands.push(PassCommand::BindPipeline(id));
 		self
@@ -190,7 +189,7 @@ impl<B: Backend> PassBuilder<'_, Graphics, B> {
 // ─── Compute impl ───────────────────────────────────────────
 // Compile-time enforced: only PassBuilder<Compute> can call these.
 
-impl<B: Backend> PassBuilder<'_, Compute, B> {
+impl PassBuilder<'_, Compute> {
 	pub fn bind_pipeline(mut self, id: PipelineId) -> Self {
 		self.commands.push(PassCommand::BindPipeline(id));
 		self
@@ -210,7 +209,7 @@ impl<B: Backend> PassBuilder<'_, Compute, B> {
 // ─── Transfer impl ──────────────────────────────────────────
 // Compile-time enforced: only PassBuilder<Transfer> can call these.
 
-impl<B: Backend> PassBuilder<'_, Transfer, B> {
+impl PassBuilder<'_, Transfer> {
 	pub fn copy_buffer(mut self, src: ResourceId, dst: ResourceId, size: u64, dst_offset: u64) -> Self {
 		self.commands.push(PassCommand::CopyBuffer { src, dst, size, dst_offset });
 		self
@@ -221,20 +220,18 @@ impl<B: Backend> PassBuilder<'_, Transfer, B> {
 /// then compiled into an execution order with automatic barrier placement.
 // Removed: 'f lifetime
 // Added:   descriptor_sets registry
-pub struct FrameGraph<B: Backend> {
+pub struct FrameGraph {
 	resources: Vec<ResourceDecl>,
 	passes: Vec<PassDecl>,
-	descriptor_sets: Vec<B::DescriptorSet>,
 	next_resource_id: ResourceId,
 	next_pass_id: PassId,
 }
 
-impl<B: Backend> FrameGraph<B> {
+impl FrameGraph {
 	pub fn new() -> Self {
 		Self {
 			resources: Vec::new(),
 			passes: Vec::new(),
-			descriptor_sets: Vec::new(),
 			next_resource_id: 0,
 			next_pass_id: 0,
 		}
@@ -246,26 +243,16 @@ impl<B: Backend> FrameGraph<B> {
 		self.resources.push(ResourceDecl { id, kind, handle });
 		id
 	}
-	pub fn add_buffer(&mut self, handle: B::Buffer) -> ResourceId {
-		self.add_resource(ResourceKind::Buffer,
-						  ResourceHandle::Buffer(B::buffer_handle(handle)))
+	pub fn add_buffer(&mut self, handle:u64) -> ResourceId {
+		self.add_resource(ResourceKind::Buffer, ResourceHandle::Buffer(handle))
 	}
 	pub fn resource(&self, id: ResourceId) -> &ResourceDecl {
 		self.resources.iter().find(|r| r.id == id).expect("resource not found")
 	}
 	
-	/// Register a raw descriptor set handle with the graph.
-	/// Returns an opaque DescriptorSetId for use in PassCommands.
-	/// The graph resolves the id → raw handle during compile/execute.
-	pub fn register_descriptor_set(&mut self, raw: B::DescriptorSet) -> DescriptorSetId {
-		let id = DescriptorSetId(self.descriptor_sets.len() as u32);
-		self.descriptor_sets.push(raw);
-		id
-	}
-	
 	// Changed: returns PassBuilder<'_, Graphics, B> (no 'f)
 	// Added:   domain, descriptor_set, commands fields in builder
-	pub fn add_graphics_pass(&mut self, pipeline: Option<PipelineId>) -> PassBuilder<'_, Graphics, B> {
+	pub fn add_graphics_pass(&mut self, pipeline: Option<PipelineId>) -> PassBuilder<'_, Graphics> {
 		let id = self.next_pass_id;
 		self.next_pass_id += 1;
 		PassBuilder {
@@ -281,7 +268,7 @@ impl<B: Backend> FrameGraph<B> {
 		}
 	}
 	
-	pub fn add_compute_pass(&mut self, pipeline: Option<PipelineId>) -> PassBuilder<'_, Compute, B> {
+	pub fn add_compute_pass(&mut self, pipeline: Option<PipelineId>) -> PassBuilder<'_, Compute> {
 		let id = self.next_pass_id;
 		self.next_pass_id += 1;
 		PassBuilder {
@@ -297,7 +284,7 @@ impl<B: Backend> FrameGraph<B> {
 		}
 	}
 	
-	pub fn add_transfer_pass(&mut self) -> PassBuilder<'_, Transfer, B> {
+	pub fn add_transfer_pass(&mut self) -> PassBuilder<'_, Transfer> {
 		let id = self.next_pass_id;
 		self.next_pass_id += 1;
 		PassBuilder {
@@ -462,7 +449,7 @@ impl<B: Backend> FrameGraph<B> {
 	}
 }
 
-impl<B: Backend> Default for FrameGraph<B> {
+impl Default for FrameGraph{
 	fn default() -> Self {
 		Self::new()
 	}
@@ -490,14 +477,13 @@ pub struct CompiledPass {
 
 // Removed: 'f lifetime
 // Added:   descriptor_sets: Vec<B::DescriptorSet> (registry carried from FrameGraph)
-pub struct CompiledGraph<B: Backend> {
+pub struct CompiledGraph {
 	pub order: ExecutionOrder,
 	pub passes: Vec<CompiledPass>,
 	pub resources: Vec<ResourceDecl>,
-	pub descriptor_sets: Vec<B::DescriptorSet>,
 }
 
-impl<B: Backend> FrameGraph<B> {
+impl  FrameGraph {
 	
 	/// Full compilation step.
 	///
@@ -505,7 +491,7 @@ impl<B: Backend> FrameGraph<B> {
 	///
 	/// Phase 1: dependency + barrier analysis
 	/// Phase 2: lowering PassDecl → CompiledPass
-	pub fn compile(self) -> Result<CompiledGraph<B>, GraphError> {
+	pub fn compile(self) -> Result<CompiledGraph, GraphError> {
 		// ─────────────────────────────────────────────
 		// Phase 1: dependency compilation
 		// ─────────────────────────────────────────────
@@ -528,7 +514,6 @@ impl<B: Backend> FrameGraph<B> {
 			order,
 			passes: compiled_passes,
 			resources: self.resources,
-			descriptor_sets: self.descriptor_sets,
 		})
 	}
 }

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -43,7 +43,7 @@ pub use resource::{
 	Sampler,
 };
 
-pub use exec::frame::FrameGraph;
+pub use exec::frame::{PassBuilder, FrameGraph};
 pub use exec::push_data;
 pub use exec::RenderTarget;
 pub use exec::{

--- a/src/infra/vulkan/mod.rs
+++ b/src/infra/vulkan/mod.rs
@@ -1,3 +1,4 @@
+use crate::domain::DescriptorSetId;
 use crate::core::FrameGraph;
 use crate::core::PresentSync;
 use crate::core::RenderTarget;
@@ -33,6 +34,7 @@ pub struct Glex<'dev> {
 	pipelines: PipelineManager<'dev, VulkanBackend>,
 	gpu: GpuContext<'dev, VulkanBackend>,
 	presentation: Presentation<'dev>,
+	atlas_set_id: DescriptorSetId,
 }
 
 
@@ -53,6 +55,8 @@ impl<'dev> Glex<'dev> {
 			DescriptorLayout::<VulkanBackend, TextSet>::new(ctx.device())?;
 		
 		let csd_resources = CsdResources::upload(ctx, &mut gpu, sampler_layout)?;
+		let atlas_set_id = gpu.executor_mut()
+							  .register_descriptor_set(csd_resources.atlas.descriptor_set.handle());
 		
 		
 		Ok(Self {
@@ -62,6 +66,7 @@ impl<'dev> Glex<'dev> {
 			csd_pipelines,
 			csd_resources,
 			theme: CsdTheme::default(),
+			atlas_set_id,
 		})
 	}
 	
@@ -105,11 +110,11 @@ impl<'dev> Glex<'dev> {
 		let state = window.decoration_state();
 		let draw = StandardDecorations.build_decorations(layout, state, &self.theme, title);
 		let screen_size = Vec2::new(extent.width() as f32, extent.height() as f32);
-		let mut graph = FrameGraph::<VulkanBackend>::new();
+		let mut graph = FrameGraph::new();
 		let resources = &self.csd_resources;
 		let csd = &self.csd_pipelines;
 		
-		build_csd_commands(&mut graph, resources, csd, &draw, screen_size);
+		build_csd_commands(&mut graph, resources, csd, &draw, screen_size, self.atlas_set_id);
 		
 		let signal_val = self.gpu.executor_mut()
 							 .execute(graph, swap_img, target, &self.pipelines)?;

--- a/src/renderer/windowed.rs
+++ b/src/renderer/windowed.rs
@@ -1,4 +1,5 @@
-use crate::domain::UsageIntent;
+use ash::vk::Handle;
+use crate::domain::{DescriptorSetId, UsageIntent};
 use crate::domain::ResourceHandle;
 use crate::domain::ResourceKind;
 use crate::domain::PassId;
@@ -130,19 +131,16 @@ impl<'dev, > CsdResources<'dev> {
 }
 
 pub fn build_csd_commands(
-	graph: &mut FrameGraph<VulkanBackend>,
+	graph: &mut FrameGraph,
 	resources: &CsdResources,
 	pipelines: &CsdPipelines,
 	draw: &DecorationDraw,
 	screen_size: Vec2,
+	atlas_set: DescriptorSetId,
 ) -> PassId {
 	// register the vertex buffer and descriptor set with the graph
 	let quad = &resources.quad.unit_quad_vert_buf;
-	let quad_res = graph.add_buffer(quad.handle());
-	
-	let atlas_set = graph.register_descriptor_set(
-		resources.atlas.descriptor_set.handle(),
-	);
+	let quad_res = graph.add_buffer(VulkanBackend::buffer_handle(quad.handle()));
 	
 	let mut builder = graph
 		.add_graphics_pass(None)


### PR DESCRIPTION
FrameGraph no longer carries Vec<B::DescriptorSet>. The B parameter is removed from FrameGraph, CompiledGraph, and PassBuilder. Descriptor set registration
moves to Executor, which already owns all backend handles. The graph is now pure backend-agnostic data.